### PR TITLE
Update message tag field type

### DIFF
--- a/cloudevents/scf/cmq.go
+++ b/cloudevents/scf/cmq.go
@@ -22,6 +22,6 @@ type CMQEventEntity struct {
 	MsgID			 	string 		`json:"msgId"`
 	RequestID	 		string 		`json:"requestId"`
 	MsgBody			 	string 		`json:"msgBody"`
-	MsgTag		 		[]string 	`json:"msgTag"`
+	MsgTag		 		string 	`json:"msgTag"`
 }
 


### PR DESCRIPTION
使用cmq topic出发scf，发现报错
```
返回数据:

{"errorCode":1,"errorMessage":"user code exception caught","stackTrace":"invoke function failed with err: {\"Message\":\"json: cannot unmarshal string into Go struct field CMQEventEntity.msgTag of type []string\",\"Type\":\"UnmarshalTypeError\",\"StackTrace\":null,\"ShouldExit\":false}"}
```

将msgTag 的类型修改为string，调用通过